### PR TITLE
fixed: type hinting issue in download_parallel_corpora.py

### DIFF
--- a/examples/nllb/data/download_parallel_corpora.py
+++ b/examples/nllb/data/download_parallel_corpora.py
@@ -22,6 +22,7 @@ import csv
 import gzip
 import os
 import re
+from typing import List
 import requests
 import shutil
 import tarfile
@@ -1391,7 +1392,7 @@ def download_NLLBMD(directory):
         os.remove(download_path)
 
 
-def download_Flores202(directory, eval_directions: list[str]):
+def download_Flores202(directory, eval_directions: List[str]):
     """
     https://github.com/facebookresearch/flores/blob/main/flores200/README.md
     """


### PR DESCRIPTION
Minor issue with the type hint `list[str]` for Python < 3.9 so I replaced `list` with `typing.List` in:

```python
def download_Flores202(directory, eval_directions: List[str]):
    ...
```

https://stackoverflow.com/questions/63460126/typeerror-type-object-is-not-subscriptable-in-a-function-signature